### PR TITLE
Fixed wrong exception name in __all__

### DIFF
--- a/sniffio/__init__.py
+++ b/sniffio/__init__.py
@@ -1,5 +1,10 @@
 """Top-level package for sniffio."""
 
+__all__ = [
+    "current_async_library", "AsyncLibraryNotFoundError",
+    "current_async_library_cvar"
+]
+
 from ._version import __version__
 
 from ._impl import (
@@ -7,8 +12,3 @@ from ._impl import (
     AsyncLibraryNotFoundError,
     current_async_library_cvar,
 )
-
-__all__ = [
-    "current_async_library", "UnknownAsyncLibraryError",
-    "current_async_library_cvar"
-]


### PR DESCRIPTION
The `__all__` variable was also in the wrong location according to PEP 8.