### PR TITLE
Only test Curio on 3.6+

### DIFF
--- a/sniffio/_tests/test_sniffio.py
+++ b/sniffio/_tests/test_sniffio.py
@@ -45,7 +45,7 @@ def test_asyncio():
         current_async_library()
 
 
-@pytest.mark.skipif(sys.version_info < (3.6), reason='Curio requires 3.6+')
+@pytest.mark.skipif(sys.version_info < (3, 6), reason='Curio requires 3.6+')
 def test_curio():
     import curio
 

--- a/sniffio/_tests/test_sniffio.py
+++ b/sniffio/_tests/test_sniffio.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from .. import (
@@ -43,6 +45,7 @@ def test_asyncio():
         current_async_library()
 
 
+@pytest.mark.skipif(sys.version_info < (3.6), reason='Curio requires 3.6+')
 def test_curio():
     import curio
 


### PR DESCRIPTION
Curio now requires 3.6+ and fails tests with syntax errors etc if not skipped.