### PR TITLE
PEP 561 compliance

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+# Error codes can be used to write more specific `type: ignore` comments.
+show_error_codes = True
+
+[mypy-curio.*]
+# Curio doesn't provide type hints.
+ignore_missing_imports = True
+
+[mypy-pytest.*]
+# The version of pytest used doesn't provide type hints.
+ignore_missing_imports = True

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -2,6 +2,7 @@
 
 set -ex
 
+MYPY_VERSION=0.782
 YAPF_VERSION=0.22.0
 
 if [ "$TRAVIS_OS_NAME" = "osx" ]; then
@@ -74,6 +75,19 @@ in your local checkout.
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 EOF
         exit 1
+    fi
+    pip install mypy==${MYPY_VERSION}
+    if ! mypy --pretty sniffio; then
+      cat <<EOF
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+Type checking problems were found (listed above).
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+EOF
+      exit 1
     fi
     exit 0
 fi

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     author_email="njs@pobox.com",
     license="MIT -or- Apache License 2.0",
     packages=find_packages(),
+    package_data={"sniffio": ["py.typed"]},
     install_requires=[],
     keywords=[
         "async",

--- a/sniffio/_impl.py
+++ b/sniffio/_impl.py
@@ -1,16 +1,17 @@
 from contextvars import ContextVar
+from typing import Optional
 import sys
 
 current_async_library_cvar = ContextVar(
     "current_async_library_cvar", default=None
-)
+)  # type: ContextVar[Optional[str]]
 
 
 class AsyncLibraryNotFoundError(RuntimeError):
     pass
 
 
-def current_async_library():
+def current_async_library() -> str:
     """Detect which async library is currently running.
 
     The following libraries are currently supported:

--- a/sniffio/_impl.py
+++ b/sniffio/_impl.py
@@ -66,9 +66,9 @@ def current_async_library() -> str:
     if "asyncio" in sys.modules:
         import asyncio
         try:
-            current_task = asyncio.current_task
+            current_task = asyncio.current_task  # type: ignore[attr-defined]
         except AttributeError:
-            current_task = asyncio.Task.current_task
+            current_task = asyncio.Task.current_task  # type: ignore[attr-defined]
         try:
             if current_task() is not None:
                 if (3, 7) <= sys.version_info:


### PR DESCRIPTION
Add type hints and a 'py.typed' marker file (see [PEP 561](https://www.python.org/dev/peps/pep-0561/)) to allow type checking in dependent code.

I've not added any automatic type checking or anything - I have run `mypy` over the code to confirm that my type hints are correct, though.

Not sure if this qualifies for a news fragment - happy to write one if necessary.