### PR TITLE
Fix erroneous extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,13 +15,12 @@ setup(
     license="MIT -or- Apache License 2.0",
     packages=find_packages(),
     package_data={"sniffio": ["py.typed"]},
-    install_requires=[],
+    install_requires=["contextvars >= 2.1; python_version < '3.7'"],
     keywords=[
         "async",
         "trio",
         "asyncio",
     ],
-    extras_require={":python_version < '3.7'": ["contextvars>=2.1"]},
     python_requires=">=3.5",
     tests_require=['curio'],
     classifiers=[


### PR DESCRIPTION
The dependency on contextvars is a conditional install_requires, not an
extras_require (which have a different syntax to distinguish groups of
optional dependencies).