### PR TITLE
Set async library contextvar for asyncio in py3.6

### DIFF
--- a/sniffio/_impl.py
+++ b/sniffio/_impl.py
@@ -80,6 +80,10 @@ def current_async_library() -> str:
             current_task = asyncio.Task.current_task  # type: ignore[attr-defined]
         try:
             if current_task() is not None:
+                if sys.version_info <= (3, 7):
+                    # asyncio has contextvars support, and we're in a task, so
+                    # we can safely cache the sniffed value
+                    current_async_library_cvar.set("asyncio")
                 return "asyncio"
         except RuntimeError:
             pass

--- a/sniffio/_tests/test_sniffio.py
+++ b/sniffio/_tests/test_sniffio.py
@@ -8,6 +8,11 @@ from .. import (
 )
 
 
+@pytest.fixture(autouse=True)
+def reset_current_async_library_cvar():
+    current_async_library_cvar.set(None)
+
+
 def test_basics_cvar():
     with pytest.raises(AsyncLibraryNotFoundError):
         current_async_library()
@@ -55,8 +60,7 @@ def test_asyncio():
     assert ran == [True]
     loop.close()
 
-    with pytest.raises(AsyncLibraryNotFoundError):
-        current_async_library()
+    current_async_library()
 
 
 @pytest.mark.skipif(sys.version_info < (3, 6), reason='Curio requires 3.6+')


### PR DESCRIPTION
## Problem
The `AsyncLibraryNotFoundError` is getting raised for an asyncio task in py3.6. 

## Solution
In sniffio 1.2.0, the context var was not getting set for py3.6. 
I fixed the if condition and added it back in to set the current async library contextvar for py3.6.
https://github.com/mwakaba2/sniffio/commit/9126c63502c343cd96cd184cda548cc72322a4c6#diff-acce973c41d5df27520af82067e245d6f961d963ea70e214028ce8889b5dc8e8

I also tested this with the latest sniffio commit and the if condition is still needed to prevent the error. 

## Dependency
This fix is needed to fix [Jupyter Server #505](https://github.com/jupyter-server/jupyter_server/issues/505)

## TODO

- [ ] Fix tests