### PR TITLE
Change asyncio detection to use get_running_loop

### DIFF
--- a/sniffio/_impl.py
+++ b/sniffio/_impl.py
@@ -75,6 +75,12 @@ def current_async_library() -> str:
     if "asyncio" in sys.modules:
         import asyncio
         try:
+            asyncio.get_running_loop()
+            return "asyncio"
+        except (AttributeError, RuntimeError):
+            pass
+
+        try:
             current_task = asyncio.current_task  # type: ignore[attr-defined]
         except AttributeError:
             current_task = asyncio.Task.current_task  # type: ignore[attr-defined]

--- a/sniffio/_impl.py
+++ b/sniffio/_impl.py
@@ -77,20 +77,21 @@ def current_async_library() -> str:
         try:
             asyncio.get_running_loop()
             return "asyncio"
+
         except AttributeError:
-            pass
+            try:
+                current_task = asyncio.current_task  # type: ignore[attr-defined]
+            except AttributeError:
+                current_task = asyncio.Task.current_task  # type: ignore[attr-defined]
+            try:
+                if current_task() is not None:
+                    return "asyncio"
+            except RuntimeError:
+                pass
+
         except RuntimeError:
             pass
 
-        try:
-            current_task = asyncio.current_task  # type: ignore[attr-defined]
-        except AttributeError:
-            current_task = asyncio.Task.current_task  # type: ignore[attr-defined]
-        try:
-            if current_task() is not None:
-                return "asyncio"
-        except RuntimeError:
-            pass
 
     # Sniff for curio (for now)
     if 'curio' in sys.modules:

--- a/sniffio/_impl.py
+++ b/sniffio/_impl.py
@@ -77,7 +77,9 @@ def current_async_library() -> str:
         try:
             asyncio.get_running_loop()
             return "asyncio"
-        except (AttributeError, RuntimeError):
+        except AttributeError:
+            pass
+        except RuntimeError:
             pass
 
         try:

--- a/sniffio/_tests/test_sniffio.py
+++ b/sniffio/_tests/test_sniffio.py
@@ -62,9 +62,8 @@ def test_in_call_soon_threadsafe():
     import asyncio
 
     asynclib = None
-    completed = asyncio.Event()
 
-    def sync_in_loop():
+    def sync_in_loop(completed):
         nonlocal asynclib
         try:
             asynclib = current_async_library()
@@ -72,10 +71,11 @@ def test_in_call_soon_threadsafe():
             completed.set()
 
     async def async_in_loop():
+        completed = asyncio.Event()
+        loop.call_soon_threadsafe(sync_in_loop, completed)
         await completed.wait()
 
     loop = asyncio.new_event_loop()
-    handle = loop.call_soon_threadsafe(sync_in_loop)
     loop.run_until_complete(async_in_loop())
     loop.close()
 


### PR DESCRIPTION
Attempt to solve #35 

Not sure if the other tests are still needed (get_running_loop appeared in 3.7).
Added a test to ensure this works and could add more if needed.
Havn't tested under different event loops and for now only ran the tests on 3.10