### PR TITLE
Clarify what counts as 'running'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - name: Checkout
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11-dev']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12-dev']
         check_formatting: ['0']
         extra_name: ['']
         include:
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -54,9 +54,10 @@ easy.
 **Step 1:** Pick the magic string that will identify your library. To
 avoid collisions, this should match your library's PEP 503 normalized name on PyPI.
 
-**Step 2:** There's a special :class:`threading.local` object:
+**Step 2:** There's a special :class:`threading.local` object attribute that
+sniffio consults to determine the currently running library:
 
-.. data:: thread_local.name
+.. data:: sniffio.thread_local.name
 
 Make sure that whenever your library is potentially executing user-provided code,
 this is set to your identifier string. In many cases, you can set it once when
@@ -64,15 +65,15 @@ your library starts up and restore it on shutdown:
 
 .. code-block:: python3
 
-   from sniffio import thread_local as sniffio_loop
+   from sniffio import thread_local as sniffio_library
 
    # Your library's run function (like trio.run() or asyncio.run())
    def run(...):
-       old_name, sniffio_loop.name = sniffio_loop.name, "my-library's-PyPI-name"
+       old_name, sniffio_library.name = sniffio_library.name, "my-library's-PyPI-name"
        try:
            # actual event loop implementation left as an exercise to the reader
        finally:
-           sniffio_loop.name = old_name
+           sniffio_library.name = old_name
 
 In unusual situations you may need to be more fine-grained about it:
 
@@ -87,25 +88,25 @@ In unusual situations you may need to be more fine-grained about it:
   than around an entire ``run()`` function.
 
 * If you're using something akin to `trio-asyncio
-  <https://trio-asyncio.readthedocs.io/en/latest/>`__ to implement one async
-  library on top of another, then you can set and restore :data:`thread_local.name`
-  around each task step (call to a coroutine object ``send()``, ``throw()``, or
-  ``close()`` method) into the 'inner' library. For example, trio-asyncio does
-  something like:
+  <https://trio-asyncio.readthedocs.io/en/latest/>`__ to implement one
+  async library on top of another, then you can set and restore
+  :data:`thread_local.name` around each synchronous call that might
+  execute user code on behalf of the 'inner' library.
+  For example, trio-asyncio does something like:
 
   .. code-block:: python3
 
-     from sniffio import thread_local as sniffio_loop
+     from sniffio import thread_local as sniffio_library
 
      # Your library's compatibility loop
      async def main_loop(self, ...) -> None:
          ...
          handle: asyncio.Handle = await self.get_next_handle()
-         old_name, sniffio_loop.name = sniffio_loop.name, "asyncio"
+         old_name, sniffio_library.name = sniffio_library.name, "asyncio"
          try:
              result = handle._callback(obj._args)
          finally:
-             sniffio_loop.name = old_name
+             sniffio_library.name = old_name
 
 **Step 3:** Send us a PR to add your library to the list of supported
 libraries above.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -58,47 +58,59 @@ avoid collisions, this should match your library's PEP 503 normalized name on Py
 
 .. data:: thread_local.name
 
-Make sure that whenever your library is calling a coroutine ``throw()``, ``send()``, or ``close()``
-that this is set to your identifier string. In most cases, this will be as simple as:
+Make sure that whenever your library is potentially executing user-provided code,
+this is set to your identifier string. In many cases, you can set it once when
+your library starts up and restore it on shutdown:
 
 .. code-block:: python3
 
-   from sniffio import thread_local
+   from sniffio import thread_local as sniffio_loop
 
-   # Your library's step function
-   def step(...):
-        old_name, thread_local.name = thread_local.name, "my-library's-PyPI-name"
-        try:
-            result = coro.send(None)
-        finally:
-            thread_local.name = old_name
+   # Your library's run function (like trio.run() or asyncio.run())
+   def run(...):
+       old_name, sniffio_loop.name = sniffio_loop.name, "my-library's-PyPI-name"
+       try:
+           # actual event loop implementation left as an exercise to the reader
+       finally:
+           sniffio_loop.name = old_name
+
+In unusual situations you may need to be more fine-grained about it:
+
+* If you're using something akin to Trio `guest mode
+  <https://trio.readthedocs.io/en/stable/reference-lowlevel.html#using-guest-mode-to-run-trio-on-top-of-other-event-loops>`__
+  to permit running your library on top of another event loop, then
+  you'll want to make sure that :func:`current_async_library` can
+  correctly identify which library (host or guest) is running at any
+  given moment.  To achieve this, you should set and restore
+  :data:`thread_local.name` around each "tick" of your library's logic
+  (the part that is invoked as a callback from the host loop), rather
+  than around an entire ``run()`` function.
+
+* If you're using something akin to `trio-asyncio
+  <https://trio-asyncio.readthedocs.io/en/latest/>`__ to implement one async
+  library on top of another, then you can set and restore :data:`thread_local.name`
+  around each task step (call to a coroutine object ``send()``, ``throw()``, or
+  ``close()`` method) into the 'inner' library. For example, trio-asyncio does
+  something like:
+
+  .. code-block:: python3
+
+     from sniffio import thread_local as sniffio_loop
+
+     # Your library's compatibility loop
+     async def main_loop(self, ...) -> None:
+         ...
+         handle: asyncio.Handle = await self.get_next_handle()
+         old_name, sniffio_loop.name = sniffio_loop.name, "asyncio"
+         try:
+             result = handle._callback(obj._args)
+         finally:
+             sniffio_loop.name = old_name
 
 **Step 3:** Send us a PR to add your library to the list of supported
 libraries above.
 
 That's it!
-
-There are libraries that directly drive a sniffio-naive coroutine from another,
-outer sniffio-aware coroutine such as `trio_asyncio`.
-These libraries should make sure to set the correct value
-while calling a synchronous function that will go on to drive the
-sniffio-naive coroutine.
-
-
-.. code-block:: python3
-
-   from sniffio import thread_local
-
-   # Your library's compatibility loop
-   async def main_loop(self, ...) -> None:
-        ...
-        handle: asyncio.Handle = await self.get_next_handle()
-        old_name, thread_local.name = thread_local.name, "asyncio"
-        try:
-            result = handle._callback(obj._args)
-        finally:
-            thread_local.name = old_name
-
 
 .. toctree::
    :maxdepth: 1

--- a/newsfragments/39.feature.rst
+++ b/newsfragments/39.feature.rst
@@ -1,0 +1,13 @@
+sniffio now attempts to return the expected library name when
+:func:`sniffio.current_async_library` is called from code that is
+associated with an async library but is not part of an async task.
+This includes asyncio ``call_soon()`` and ``call_later()`` callbacks, and
+Trio instrumentation and ``abort_fn`` handlers. (Previously, sniffio's
+behavior in these situations was inconsistent.) The sniffio
+documentation now explains more precisely which async library counts
+as "currently running" in ambiguous cases. Libraries other than
+asyncio may need updates to their sniffio integration in order to
+fully conform to the new semantics; the documentation includes an
+updated recipe. The new semantics also reduce the number of situations
+where updates to sniffio's internals are required, which should modestly
+improve the performance of libraries that interoperate with sniffio.

--- a/sniffio/_impl.py
+++ b/sniffio/_impl.py
@@ -1,5 +1,5 @@
 from contextvars import ContextVar
-from typing import Optional
+from typing import Callable, Optional
 import sys
 import threading
 
@@ -92,7 +92,9 @@ def current_async_library() -> str:
     if "asyncio" in sys.modules:
         import asyncio
         try:
-            test = asyncio._get_running_loop  # type: ignore[attr-defined]
+            test: Callable[
+                [], object
+            ] = asyncio._get_running_loop  # type: ignore[attr-defined]
         except AttributeError:
             # 3.6 doesn't have _get_running_loop, so we can only detect
             # asyncio if we're inside a task (as opposed to a callback)

--- a/sniffio/_impl.py
+++ b/sniffio/_impl.py
@@ -91,19 +91,8 @@ def current_async_library() -> str:
     # Need to sniff for asyncio
     if "asyncio" in sys.modules:
         import asyncio
-        try:
-            test: Callable[
-                [], object
-            ] = asyncio._get_running_loop  # type: ignore[attr-defined]
-        except AttributeError:
-            # 3.6 doesn't have _get_running_loop, so we can only detect
-            # asyncio if we're inside a task (as opposed to a callback)
-            test = asyncio.Task.current_task  # type: ignore[attr-defined]
-        try:
-            if test() is not None:
-                return "asyncio"
-        except RuntimeError:
-            pass
+        if asyncio._get_running_loop() is not None:
+            return "asyncio"
 
     # Sniff for curio (for now)
     if 'curio' in sys.modules:

--- a/sniffio/_tests/test_sniffio.py
+++ b/sniffio/_tests/test_sniffio.py
@@ -65,7 +65,8 @@ def test_asyncio():
 # 3.12 error is from importing a private name that no longer exists in the
 # multiprocessing module; unclear if it's going to be fixed or not.
 @pytest.mark.skipif(
-    (os.name == "nt" and sys.version_info >= (3, 9)) or sys.version_info >= (3, 12),
+    (os.name == "nt" and sys.version_info >= (3, 9))
+    or sys.version_info >= (3, 12),
     reason="Curio breaks on Python 3.9+ on Windows and 3.12+ everywhere",
 )
 def test_curio():

--- a/sniffio/_tests/test_sniffio.py
+++ b/sniffio/_tests/test_sniffio.py
@@ -45,23 +45,28 @@ def test_asyncio():
 
     ran = []
 
+    def test_from_callback():
+        assert current_async_library() == "asyncio"
+        ran.append(2)
+
     async def this_is_asyncio():
+        asyncio.get_running_loop().call_soon(test_from_callback)
         assert current_async_library() == "asyncio"
-        # Call it a second time to exercise the caching logic
-        assert current_async_library() == "asyncio"
-        ran.append(True)
+        ran.append(1)
 
     asyncio.run(this_is_asyncio())
-    assert ran == [True]
+    assert ran == [1, 2]
 
     with pytest.raises(AsyncLibraryNotFoundError):
         current_async_library()
 
 
-# https://github.com/dabeaz/curio/pull/354
+# https://github.com/dabeaz/curio/pull/354 has the Windows/3.9 fix.
+# 3.12 error is from importing a private name that no longer exists in the
+# multiprocessing module; unclear if it's going to be fixed or not.
 @pytest.mark.skipif(
-    os.name == "nt" and sys.version_info >= (3, 9),
-    reason="Curio breaks on Python 3.9+ on Windows. Fix was not released yet",
+    (os.name == "nt" and sys.version_info >= (3, 9)) or sys.version_info >= (3, 12),
+    reason="Curio breaks on Python 3.9+ on Windows and 3.12+ everywhere",
 )
 def test_curio():
     import curio
@@ -72,8 +77,6 @@ def test_curio():
     ran = []
 
     async def this_is_curio():
-        assert current_async_library() == "curio"
-        # Call it a second time to exercise the caching logic
         assert current_async_library() == "curio"
         ran.append(True)
 


### PR DESCRIPTION
As proposed in #38, this PR updates sniffio's documentation and `asyncio` detection to adopt a consistent stance on what counts as "currently running". Now, user code that is invoked by an async library but is not part of an async task will still return that async library from `sniffio.current_async_library()`.

Fixes #35. Fixes #38.