### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           cache: pip
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11-dev']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
         check_formatting: ['0']
         extra_name: ['']
         include:
@@ -43,16 +43,16 @@ jobs:
             extra_name: ', check formatting'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         if: "!endsWith(matrix.python, '-dev')"
         with:
           python-version: ${{ matrix.python }}
           cache: pip
           cache-dependency-path: test-requirements.txt
       - name: Setup python (dev)
-        uses: deadsnakes/action@v2.0.2
+        uses: deadsnakes/action@v2.1.1
         if: endsWith(matrix.python, '-dev')
         with:
           python-version: '${{ matrix.python }}'
@@ -70,12 +70,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           cache: pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - name: Checkout
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
           cache: pip
           cache-dependency-path: test-requirements.txt
       - name: Run tests
@@ -34,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12-dev']
         check_formatting: ['0']
         extra_name: ['']
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup python
         uses: actions/setup-python@v4
         with:
@@ -43,7 +43,7 @@ jobs:
             extra_name: ', check formatting'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup python
         uses: actions/setup-python@v4
         if: "!endsWith(matrix.python, '-dev')"
@@ -52,7 +52,7 @@ jobs:
           cache: pip
           cache-dependency-path: test-requirements.txt
       - name: Setup python (dev)
-        uses: deadsnakes/action@v2.1.1
+        uses: deadsnakes/action@v3.0.1
         if: endsWith(matrix.python, '-dev')
         with:
           python-version: '${{ matrix.python }}'
@@ -73,7 +73,7 @@ jobs:
         python: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -79,6 +79,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
           cache: pip
           cache-dependency-path: test-requirements.txt
       - name: Run tests

--- a/sniffio/_tests/test_sniffio.py
+++ b/sniffio/_tests/test_sniffio.py
@@ -58,11 +58,6 @@ def test_asyncio():
         current_async_library()
 
 
-# https://github.com/dabeaz/curio/pull/354
-@pytest.mark.skipif(
-    os.name == "nt" and sys.version_info >= (3, 9),
-    reason="Curio breaks on Python 3.9+ on Windows. Fix was not released yet",
-)
 @pytest.mark.skipif(
     sys.version_info >= (3, 12),
     reason=

--- a/sniffio/_tests/test_sniffio.py
+++ b/sniffio/_tests/test_sniffio.py
@@ -63,6 +63,11 @@ def test_asyncio():
     os.name == "nt" and sys.version_info >= (3, 9),
     reason="Curio breaks on Python 3.9+ on Windows. Fix was not released yet",
 )
+@pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason=
+    "curio broken on 3.12 (https://github.com/python-trio/sniffio/pull/42)",
+)
 def test_curio():
     import curio
 


### PR DESCRIPTION
The [second and final Python 3.12 release candidate](https://discuss.python.org/t/python-3-12-0rc2-final-release-candidate-released/33105/5?u=hugovk) is out! :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

The final release is due in three weeks on 2023-10-02.

---


# Bug report

Consider this a PR a bug report, the Python 3.12 build fails:

```pytb
=================================== FAILURES ===================================
__________________________________ test_curio __________________________________

    @pytest.mark.skipif(
        os.name == "nt" and sys.version_info >= (3, 9),
        reason="Curio breaks on Python 3.9+ on Windows. Fix was not released yet",
    )
    def test_curio():
>       import curio

../../../../venv-3.12/lib/python3.12/site-packages/sniffio/_tests/test_sniffio.py:67: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../../../venv-3.12/lib/python3.12/site-packages/curio/__init__.py:6: in <module>
    from .queue import *
../../../../venv-3.12/lib/python3.12/site-packages/curio/queue.py:20: in <module>
    from . import workers
../../../../venv-3.12/lib/python3.12/site-packages/curio/workers.py:23: in <module>
    from .channel import Connection
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    # channel.py
    #
    # Support for a message passing channel that can send bytes or pickled
    # Python objects on a stream.  Compatible with the Connection class in the
    # multiprocessing module, but rewritten for a purely asynchronous runtime.
    
    __all__ = ['Channel']
    
    # -- Standard Library
    
    import os
    import pickle
    import struct
    import hmac
    import multiprocessing.connection as mpc
    import logging
    
    log = logging.getLogger(__name__)
    
    # -- Curio
    
    from . import socket
    from .errors import CurioError, TaskTimeout
    from .io import StreamBase, FileStream
    from . import thread
    from .time import timeout_after, sleep
    
    # Authentication parameters (copied from multiprocessing)
    
    AUTH_MESSAGE_LENGTH = mpc.MESSAGE_LENGTH    # 20
>   CHALLENGE = mpc.CHALLENGE                   # b'#CHALLENGE#'
E   AttributeError: module 'multiprocessing.connection' has no attribute 'CHALLENGE'. Did you mean: '_CHALLENGE'?
```

This is because dependency curio doesn't support Python 3.12 yet. This issue/PR has suggestions how to fix it: https://github.com/dabeaz/curio/issues/361 / https://github.com/dabeaz/curio/pull/363.

Further:

> ## Important Notice: October 25, 2022
> The Curio project is no longer making package releases. I'm more than happy to accept bug reports and may continue to work on it from time to time as the mood strikes. If you want the absolute latest version, you should vendor the source code from here. Curio has no dependencies other than the Python standard library. --Dave

So you'll need to either vendor and fix curio, or replace it with something else.

Feel free to use this PR as a starting point for fixing it as you see best, or close this as needed.

Thanks!