### PR TITLE
Add support for Python 3.13-3.14 and drop support EOL 3.7-3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,12 +90,12 @@ jobs:
   alls-green:
     if: always()
     needs:
-    - Windows
-    - Ubuntu
-    - macOS
+      - Windows
+      - Ubuntu
+      - macOS
     runs-on: ubuntu-latest
     steps:
-    - name: Decide whether all jobs succeeded or not
-      uses: re-actors/alls-green@release/v1
-      with:
-        jobs: ${{ toJSON(needs) }}
+      - name: Decide whether all jobs succeeded or not
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,16 @@ jobs:
         env:
           # Should match 'name:' up above
           JOB_NAME: 'macOS (${{ matrix.python }})'
+
+  alls-green:
+    if: always()
+    needs:
+    - Windows
+    - Ubuntu
+    - macOS
+    runs-on: ubuntu-latest
+    steps:
+    - name: Decide whether all jobs succeeded or not
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,17 +47,11 @@ jobs:
         uses: actions/checkout@v6
       - name: Setup Python
         uses: actions/setup-python@v6
-        if: "!endsWith(matrix.python, '-dev')"
         with:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
           cache: pip
           cache-dependency-path: test-requirements.txt
-      - name: Setup Python (dev)
-        uses: deadsnakes/action@v3.2.0
-        if: endsWith(matrix.python, '-dev')
-        with:
-          python-version: '${{ matrix.python }}'
       - name: Run tests
         run: ./ci.sh
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
         if: "!endsWith(matrix.python, '-dev')"
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
           cache: pip
           cache-dependency-path: test-requirements.txt
       - name: Setup Python (dev)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
+        python: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
 
     steps:
       - name: Checkout
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
+        python: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
         check_formatting: ['0']
         extra_name: ['']
         include:
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
+        python: ['3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   Windows:
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
 
     steps:
       - name: Checkout
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
         check_formatting: ['0']
         extra_name: ['']
         include:
@@ -53,7 +53,7 @@ jobs:
           cache: pip
           cache-dependency-path: test-requirements.txt
       - name: Setup Python (dev)
-        uses: deadsnakes/action@v3.0.1
+        uses: deadsnakes/action@v3.2.0
         if: endsWith(matrix.python, '-dev')
         with:
           python-version: '${{ matrix.python }}'
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,10 @@ jobs:
           allow-prereleases: true
           cache: pip
           cache-dependency-path: test-requirements.txt
+      - name: Set PYTHON_GIL
+        if: endsWith(matrix.python-version, 't')
+        run: |
+          echo "PYTHON_GIL=0" >> "$GITHUB_ENV"
       - name: Run tests
         run: ./ci.sh
         env:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,9 +2,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.8"
+    python: "3.13"
 
 formats:
   - htmlzip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,9 +2,12 @@
 version: 2
 
 build:
-  os: ubuntu-24.04
+  os: ubuntu-22.04
   tools:
-    python: "3.13"
+    python: "3.8"
+
+sphinx:
+  configuration: docs/source/conf.py
 
 formats:
   - htmlzip

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,9 +6,6 @@ build:
   tools:
     python: "3.8"
 
-sphinx:
-  configuration: docs/source/conf.py
-
 formats:
   - htmlzip
   - epub

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Development Status :: 5 - Production/Stable",
 ]
-requires-python = ">= 3.7"
+requires-python = ">= 3.9"
 dynamic = ["version"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Development Status :: 5 - Production/Stable",
 ]
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 dynamic = ["version"]
 
 [project.urls]


### PR DESCRIPTION
See https://devguide.python.org/versions/

Python 3.7 is no longer available on GitHub Actions:

* https://github.com/hugovk/sniffio/actions/runs/13589302770
* https://github.com/actions/setup-python/issues/962#issuecomment-2414418045