### PR TITLE
.readthedocs.yml: Ubuntu-24.04's default Python is 3.12

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,9 +2,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.8"
+    python: "3.12"
 
 formats:
   - htmlzip


### PR DESCRIPTION
Upgrade from end-of-life Python v3.8 to v3.12.
* https://documentation.ubuntu.com/ubuntu-for-developers/reference/availability/python