### PR TITLE
Migrated requirements.txt files to dependency groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
           cache: pip
-          cache-dependency-path: test-requirements.txt
+          cache-dependency-path: pyproject.toml
       - name: Run tests
         run: ./ci.sh
         shell: bash
@@ -51,7 +51,7 @@ jobs:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
           cache: pip
-          cache-dependency-path: test-requirements.txt
+          cache-dependency-path: pyproject.toml
       - name: Run tests
         run: ./ci.sh
         env:
@@ -76,7 +76,7 @@ jobs:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
           cache: pip
-          cache-dependency-path: test-requirements.txt
+          cache-dependency-path: pyproject.toml
       - name: Set PYTHON_GIL
         if: endsWith(matrix.python-version, 't')
         run: |

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,15 +4,15 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.10"
+  jobs:
+    install:
+      - python -m pip install --no-cache-dir "pip >= 25.1"
+      - python -m pip install --upgrade --upgrade-strategy only-if-needed --no-cache-dir --group rtd .
 
 formats:
   - htmlzip
   - epub
-
-python:
-  install:
-    - requirements: ci/rtd-requirements.txt
 
 sphinx:
   configuration: docs/source/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,9 +2,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.12"
   jobs:
     install:
       - python -m pip install --no-cache-dir "pip >= 25.1"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,4 @@
 include README.rst CHEATSHEET.rst LICENSE* CODE_OF_CONDUCT* CONTRIBUTING*
 include .coveragerc .style.yapf
-include test-requirements.txt
 recursive-include docs *
 prune docs/build

--- a/ci.sh
+++ b/ci.sh
@@ -43,7 +43,7 @@ EOF
     exit 0
 fi
 
-pip install -U --group test .
+pip install --upgrade --group test .
 
 mkdir empty
 cd empty

--- a/ci.sh
+++ b/ci.sh
@@ -43,10 +43,7 @@ EOF
     exit 0
 fi
 
-pip install .
-
-# Actual tests
-pip install -Ur test-requirements.txt
+pip install -U --group test .
 
 mkdir empty
 cd empty

--- a/ci/rtd-requirements.txt
+++ b/ci/rtd-requirements.txt
@@ -1,4 +1,0 @@
-# RTD is currently installing 1.5.3, which has a bug in :lineno-match:
-sphinx >= 1.6.1
-sphinx_rtd_theme
-sphinxcontrib-trio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,18 @@ Homepage = "https://github.com/python-trio/sniffio"
 Documentation = "https://sniffio.readthedocs.io/"
 Changelog = "https://sniffio.readthedocs.io/en/latest/history.html"
 
+[dependency-groups]
+test = [
+    "pytest",
+    "pytest-cov",
+    "curio",
+]
+rtd = [
+    "sphinx >= 1.6.1",
+    "sphinx_rtd_theme",
+    "sphinxcontrib-trio",
+]
+
 [tool.setuptools.dynamic]
 version = {attr = "sniffio._version.__version__"}
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,0 @@
-pytest
-pytest-cov
-curio


### PR DESCRIPTION
I have not modified the actual dependencies. However, there are issues that might warrant attention:

- Using the `-U` flag with pip does not work well with the cache
- Maybe the dependencies could use more lower bounds, and the existing lower bounds an update?